### PR TITLE
refactor(options): Separate old SPR,TBR mintrav,maxtrav options to ne…

### DIFF
--- a/iqtree.cpp
+++ b/iqtree.cpp
@@ -2533,11 +2533,12 @@ string IQTree::doNNISearch(int &nniCount, int &nniSteps) {
                 }
             } else if (params->uppass_tbr == true) {
                 pllOptimizeTbrUppass(pllInst, pllPartitions,
-                                     params->tbr_mintrav, params->tbr_maxtrav,
-                                     this);
+                                     params->uppass_tbr_mintrav,
+                                     params->uppass_tbr_maxtrav, this);
             } else if (params->uppass_spr == true) {
                 pllOptimizeSprUppass(pllInst, pllPartitions,
-                                     params->spr_mintrav, max_spr_rad, this);
+                                     params->uppass_spr_mintrav,
+                                     params->uppass_spr_maxtrav, this);
             } else {
                 pllOptimizeSprParsimony(pllInst, pllPartitions,
                                         params->spr_mintrav, max_spr_rad, this);

--- a/tools.cpp
+++ b/tools.cpp
@@ -27,7 +27,7 @@ VerboseMode verbose_mode;
         WIN32 does not define gettimeofday() function.
         Here declare it extra for WIN32 only.
  */
-//#if defined(WIN32) && !defined(HAVE_GETTIMEOFDAY)
+// #if defined(WIN32) && !defined(HAVE_GETTIMEOFDAY)
 #if defined(WIN32)
 #include <sstream>
 #endif
@@ -41,9 +41,9 @@ VerboseMode verbose_mode;
 //    t->tv_sec = timebuffer.time;
 //    t->tv_usec = 1000 * timebuffer.millitm;
 //}
-//#else
-//#include <sys/time.h>
-//#endif
+// #else
+// #include <sys/time.h>
+// #endif
 
 /********************************************************
         Defining DoubleMatrix methods
@@ -613,6 +613,10 @@ void parseArg(int argc, char *argv[], Params &params) {
     params.test_uppass = false;
     params.uppass_tbr = false;
     params.uppass_spr = false;
+    params.uppass_tbr_mintrav = 1;
+    params.uppass_tbr_maxtrav = 5;
+    params.uppass_spr_mintrav = 1;
+    params.uppass_spr_maxtrav = 6;
     params.tree_gen = NONE;
     params.user_file = NULL;
     params.out_prefix = NULL;
@@ -1008,6 +1012,36 @@ void parseArg(int argc, char *argv[], Params &params) {
 
             if (strcmp(argv[cnt], "-uppass_spr") == 0) {
                 params.uppass_spr = true;
+                continue;
+            }
+
+            if (strcmp(argv[cnt], "-uppass_tbr_mintrav") == 0) {
+                cnt++;
+                if (cnt >= argc)
+                    throw "Use -uppass_tbr_mintrav <mintrav>";
+                params.uppass_tbr_mintrav = convert_int(argv[cnt]);
+                continue;
+            }
+            if (strcmp(argv[cnt], "-uppass_tbr_maxtrav") == 0) {
+                cnt++;
+                if (cnt >= argc)
+                    throw "Use -uppass_tbr_maxtrav <maxtrav>";
+                params.uppass_tbr_maxtrav = convert_int(argv[cnt]);
+                continue;
+            }
+
+            if (strcmp(argv[cnt], "-uppass_spr_mintrav") == 0) {
+                cnt++;
+                if (cnt >= argc)
+                    throw "Use -uppass_spr_mintrav <mintrav>";
+                params.uppass_spr_mintrav = convert_int(argv[cnt]);
+                continue;
+            }
+            if (strcmp(argv[cnt], "-uppass_spr_maxtrav") == 0) {
+                cnt++;
+                if (cnt >= argc)
+                    throw "Use -uppass_spr_maxtrav <maxtrav>";
+                params.uppass_spr_maxtrav = convert_int(argv[cnt]);
                 continue;
             }
 

--- a/tools.h
+++ b/tools.h
@@ -523,6 +523,14 @@ struct Params {
     bool uppass_tbr;
     bool uppass_spr;
 
+
+    /**
+     *  Uppass SPR's and TBR's radius
+     */
+    int uppass_tbr_mintrav;
+    int uppass_tbr_maxtrav;
+    int uppass_spr_mintrav;
+    int uppass_spr_maxtrav;
     /**
      *  Number of starting parsimony trees
      */


### PR DESCRIPTION
…w UPPASS SPR,TBR mintrav maxtrav options

Separate to new `-uppass_spr_mintrav`, `-uppass_spr_maxtrav`, `-uppass_tbr_mintrav`, `-uppass_tbr_maxtrav` options

As the old `-spr_mintrav` and `-spr_maxtrav` also used in the generating candidate trees phase and I want that phase to be intact.